### PR TITLE
Implement own Id class that hides its internal id

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="15" />
+    <bytecodeTargetLevel target="14" />
   </component>
 </project>

--- a/src/main/java/org/iogame/StaticSettings.java
+++ b/src/main/java/org/iogame/StaticSettings.java
@@ -1,0 +1,11 @@
+package org.iogame;
+
+public final class StaticSettings {
+
+    public enum Environment {
+        DEVELOPMENT,
+        PRODUCTION
+    }
+
+    public static Environment ENV = Environment.DEVELOPMENT;
+}

--- a/src/main/java/org/iogame/controller/FleetController.java
+++ b/src/main/java/org/iogame/controller/FleetController.java
@@ -1,5 +1,6 @@
 package org.iogame.controller;
 
+import org.iogame.core.Id;
 import org.iogame.main.Server;
 import org.iogame.model.fleet.Fleet;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,12 +22,7 @@ public class FleetController {
 
     @RequestMapping("/fleets")
     public List<Fleet> getFleets(@PathVariable String id) {
-        //for easy developing
-        if(id.equals("1")){
-            UUID uuid = server.getGameUUIDs().iterator().next();
-            id=uuid.toString();
-        }
-        List<Fleet> fleets = server.getGameById(UUID.fromString(id)).getFleets();
+        List<Fleet> fleets = server.getGameById(Id.fromString(id)).getFleets();
         return fleets;
     }
 

--- a/src/main/java/org/iogame/controller/GameController.java
+++ b/src/main/java/org/iogame/controller/GameController.java
@@ -1,5 +1,6 @@
 package org.iogame.controller;
 
+import org.iogame.core.Id;
 import org.iogame.main.Server;
 import org.iogame.model.player.Player;
 import org.iogame.model.player.Team;
@@ -22,23 +23,13 @@ public class GameController {
 
     @RequestMapping("/teams")
     public List<Team>  getTeams(@PathVariable String id) {
-        //for easy developing
-        if(id.equals("1")){
-            UUID uuid = server.getGameUUIDs().iterator().next();
-            id=uuid.toString();
-        }
-        List<Team> teams = server.getGameById(UUID.fromString(id)).getTeams();
+        List<Team> teams = server.getGameById(Id.fromString(id)).getTeams();
         return teams;
     }
 
     @RequestMapping("/players")
     public List<Player>  getPlayers(@PathVariable String id) {
-        //for easy developing
-        if(id.equals("1")){
-            UUID uuid = server.getGameUUIDs().iterator().next();
-            id=uuid.toString();
-        }
-        List<Player> players = server.getGameById(UUID.fromString(id)).getPlayers();
+        List<Player> players = server.getGameById(Id.fromString(id)).getPlayers();
         return players;
     }
 }

--- a/src/main/java/org/iogame/controller/MapController.java
+++ b/src/main/java/org/iogame/controller/MapController.java
@@ -1,5 +1,6 @@
 package org.iogame.controller;
 
+import org.iogame.core.Id;
 import org.iogame.main.Game;
 import org.iogame.main.Server;
 import org.iogame.model.battle.Battle;
@@ -16,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @CrossOrigin(origins = "http://localhost:3000")
 @RestController
@@ -28,12 +28,7 @@ public class MapController {
 
     @RequestMapping("/planets")
     public List<PlanetSync>  getPlanets(@PathVariable String id) {
-        //Testing
-        if(id.equals("1")){
-            UUID uuid = server.getGameUUIDs().iterator().next();
-            id=uuid.toString();
-        }
-        Game game = server.getGameById(UUID.fromString(id));
+        Game game = server.getGameById(Id.fromString(id));
 
         List<PlanetSync> planets=new ArrayList<>();
         for (Planet p:game.getPlanets()) {
@@ -44,12 +39,7 @@ public class MapController {
 
     @RequestMapping("/fleets")
     public List<FleetSync> getFleets(@PathVariable String id) {
-        //Testing
-        if(id.equals("1")){
-            UUID uuid = server.getGameUUIDs().iterator().next();
-            id=uuid.toString();
-        }
-        Game game = server.getGameById(UUID.fromString(id));
+        Game game = server.getGameById(Id.fromString(id));
 
         List<FleetSync> fleets =new ArrayList<>();
         for (Fleet f:game.getFleets()) {
@@ -60,12 +50,7 @@ public class MapController {
 
     @RequestMapping("/battles")
     public List<BattleSync>  getBattles(@PathVariable String id) {
-        //Testing
-        if(id.equals("1")){
-            UUID uuid = server.getGameUUIDs().iterator().next();
-            id=uuid.toString();
-        }
-        Game game = server.getGameById(UUID.fromString(id));
+        Game game = server.getGameById(Id.fromString(id));
 
         List<BattleSync> battles =new ArrayList<>();
         for (Battle b:game.getBattles()) {

--- a/src/main/java/org/iogame/controller/PlanetController.java
+++ b/src/main/java/org/iogame/controller/PlanetController.java
@@ -1,8 +1,8 @@
 package org.iogame.controller;
 
+import org.iogame.core.Id;
 import org.iogame.main.Server;
 import org.iogame.model.planet.Planet;
-import org.iogame.model.player.Team;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,26 +22,14 @@ public class PlanetController {
 
     @RequestMapping("/planets")
     public List<Planet> getPlanets(@PathVariable String id) {
-        //for easy developing
-        if(id.equals("1")){
-            UUID uuid = server.getGameUUIDs().iterator().next();
-            id=uuid.toString();
-        }
-
-        List<Planet> planets = server.getGameById(UUID.fromString(id)).getPlanets();
+        List<Planet> planets = server.getGameById(Id.fromString(id)).getPlanets();
 
         return planets;
     }
 
     @RequestMapping("/planets/{planetId}")
     public Planet getPlanets(@PathVariable String id,@PathVariable String planetId) {
-        //for easy developing
-        if(id.equals("1")){
-            UUID uuid = server.getGameUUIDs().iterator().next();
-            id=uuid.toString();
-        }
-
-        Planet planet = server.getGameById(UUID.fromString(id)).getPlanets().get(Integer.valueOf(planetId));
+        Planet planet = server.getGameById(Id.fromString(id)).getPlanets().get(Integer.valueOf(planetId));
 
         return planet;
     }

--- a/src/main/java/org/iogame/controller/ServerController.java
+++ b/src/main/java/org/iogame/controller/ServerController.java
@@ -1,5 +1,6 @@
 package org.iogame.controller;
 
+import org.iogame.core.Id;
 import org.iogame.main.Server;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -8,7 +9,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @CrossOrigin(origins = "http://localhost:3000")
 @RestController
@@ -29,7 +29,7 @@ public class ServerController {
     @RequestMapping("/newgame")
     public String createGame() {
         if(server.getGameNumbers()<maxGames) {
-            UUID id = server.createGame("game" + server.getGameNumbers());
+            Id id = server.createGame("game" + server.getGameNumbers());
             return "http://localhost:8080/game/map/planets/"+id.toString()+"";
         }else {
             return "";
@@ -39,7 +39,7 @@ public class ServerController {
     @RequestMapping("/gameids")
     public List<String> games() {
         List<String> list = new ArrayList<>();
-        for (UUID uuid:server.getGameUUIDs()) {
+        for (Id uuid:server.getGameIDs()) {
             list.add(uuid.toString());
         }
         return list;

--- a/src/main/java/org/iogame/core/GameObject.java
+++ b/src/main/java/org/iogame/core/GameObject.java
@@ -1,18 +1,16 @@
-package org.iogame.model;
-
-import java.util.UUID;
+package org.iogame.core;
 
 public abstract class GameObject {
 
-    private final UUID id;
+    private final Id id;
     private final String name;
 
     public GameObject() {
-        this.id = UUID.randomUUID();
+        this.id = Id.generateForClass(getClass());
         this.name = String.format("%s (%s)", getClass().getSimpleName(), id);
     }
 
-    public UUID getId() {
+    public Id getId() {
         return this.id;
     }
 

--- a/src/main/java/org/iogame/core/Id.java
+++ b/src/main/java/org/iogame/core/Id.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
 
 import static org.iogame.StaticSettings.ENV;
 
@@ -15,8 +14,6 @@ public class Id {
     private static final Map<Class<?>, AtomicLong> LONG_ID_POOL = new HashMap<>();
 
     private final Object value;
-
-    private final EqualityFunction equalityFunction;
 
     public static Id generate() {
         return generateForClass(Object.class);
@@ -52,7 +49,6 @@ public class Id {
 
     Id(Object value) {
         this.value = value;
-        this.equalityFunction = other -> this.value.equals(other.value);
     }
 
     public <T> T getValue() {
@@ -62,14 +58,11 @@ public class Id {
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof Id)) return false;
-        return this.equalityFunction.apply((Id) obj);
+        return this.value.equals(((Id) obj).value);
     }
 
     @Override
     public String toString() {
         return value.toString();
     }
-
-    @FunctionalInterface
-    interface EqualityFunction extends Function<Id, Boolean> {}
 }

--- a/src/main/java/org/iogame/core/Id.java
+++ b/src/main/java/org/iogame/core/Id.java
@@ -1,0 +1,75 @@
+package org.iogame.core;
+
+import org.iogame.StaticSettings.Environment;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+import static org.iogame.StaticSettings.ENV;
+
+public class Id {
+
+    private static final Map<Class<?>, AtomicLong> LONG_ID_POOL = new HashMap<>();
+
+    private final Object value;
+
+    private final EqualityFunction equalityFunction;
+
+    public static Id generate() {
+        return generateForClass(Object.class);
+    }
+
+    public static Id generateForClass(Class<?> clazz) {
+        Object value = null;
+        if (ENV == Environment.DEVELOPMENT) {
+            value = LONG_ID_POOL.computeIfAbsent(clazz, __ -> new AtomicLong(0)).getAndIncrement();
+        }
+        if (ENV == Environment.PRODUCTION) {
+            value = UUID.randomUUID();
+        }
+        if (value == null) {
+            throw new IllegalArgumentException(String.format("Environment %s is not registered.", ENV));
+        }
+        return new Id(value);
+    }
+
+    public static Id fromString(String stringValue) {
+        Object value = null;
+        if (ENV == Environment.DEVELOPMENT) {
+            value = Long.valueOf(stringValue);
+        }
+        if (ENV == Environment.PRODUCTION) {
+            value = UUID.fromString(stringValue);
+        }
+        if (value == null) {
+            throw new IllegalArgumentException(String.format("Environment %s is not registered.", ENV));
+        }
+        return new Id(value);
+    }
+
+    Id(Object value) {
+        this.value = value;
+        this.equalityFunction = other -> this.value.equals(other.value);
+    }
+
+    public <T> T getValue() {
+        return (T) value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Id)) return false;
+        return this.equalityFunction.apply((Id) obj);
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @FunctionalInterface
+    interface EqualityFunction extends Function<Id, Boolean> {}
+}

--- a/src/main/java/org/iogame/main/Game.java
+++ b/src/main/java/org/iogame/main/Game.java
@@ -1,7 +1,8 @@
 package org.iogame.main;
 
+import org.iogame.core.Id;
 import org.iogame.model.battle.Battle;
-import org.iogame.model.GameObject;
+import org.iogame.core.GameObject;
 import org.iogame.model.fleet.Fleet;
 import org.iogame.model.planet.Planet;
 import org.iogame.model.player.Player;
@@ -14,7 +15,7 @@ public class Game extends Thread {
     private static final int MAX_PLAYERS = 5;
     private final String name;
 
-    private final Map<Class<? extends GameObject>, Map<UUID, GameObject>> gameObjects;
+    private final Map<Class<? extends GameObject>, Map<Id, GameObject>> gameObjects;
 
     private final List<Player> players;
     private final List<Team> teams;
@@ -72,7 +73,7 @@ public class Game extends Thread {
      * This method will be called for every frame in the main loop.
      */
     public void update(long delta) {
-        for (Map<UUID, GameObject> innerMap : gameObjects.values()) {
+        for (Map<Id, GameObject> innerMap : gameObjects.values()) {
             for (GameObject gameObject : innerMap.values()) {
                 gameObject.update(delta);
             }
@@ -107,7 +108,7 @@ public class Game extends Thread {
     }
 
     public void addGameObject(GameObject gameObject) {
-        Map<UUID, GameObject> gameObjectList = this.gameObjects.computeIfAbsent(gameObject.getClass(), ignore -> new IdentityHashMap<>());
+        Map<Id, GameObject> gameObjectList = this.gameObjects.computeIfAbsent(gameObject.getClass(), ignore -> new IdentityHashMap<>());
         gameObjectList.put(gameObject.getId(), gameObject);
     }
 
@@ -127,11 +128,11 @@ public class Game extends Thread {
         return teams;
     }
 
-    public Planet getPlanetById(UUID id) {
+    public Planet getPlanetById(Id id) {
         return (Planet) this.gameObjects.get(Planet.class).get(id);
     }
 
-    public Fleet getFleetById(UUID id) {
+    public Fleet getFleetById(Id id) {
         return (Fleet) this.gameObjects.get(Fleet.class).get(id);
     }
 

--- a/src/main/java/org/iogame/main/Server.java
+++ b/src/main/java/org/iogame/main/Server.java
@@ -1,5 +1,6 @@
 package org.iogame.main;
 
+import org.iogame.core.Id;
 import org.iogame.model.player.Player;
 import org.jetbrains.annotations.TestOnly;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,7 @@ public final class Server {
         return server;
     }
 
-    private final Map<UUID, Game> games;
+    private final Map<Id, Game> games;
 
     private Server() {
         this.games = new HashMap<>();
@@ -25,9 +26,9 @@ public final class Server {
      *
      * @param name Name of the game instance
      */
-    public UUID createGame(String name) {
+    public Id createGame(String name) {
         Game game = new Game(name);
-        UUID uuid = UUID.randomUUID();
+        Id uuid = Id.generate();
         this.games.put(uuid, game);
         game.start();
         return uuid;
@@ -36,7 +37,7 @@ public final class Server {
     /**
      * Adds a player to a running game.
      */
-    public void joinGame(Player player, UUID gameId) {
+    public void joinGame(Player player, Id gameId) {
         if (games.containsKey(gameId)) {
             getGameById(gameId).join(player);
         }
@@ -47,7 +48,7 @@ public final class Server {
         return this.games.values();
     }
 
-    public Game getGameById(UUID gameId) {
+    public Game getGameById(Id gameId) {
         return this.games.get(gameId);
     }
 
@@ -55,8 +56,8 @@ public final class Server {
         return  games.size();
     }
 
-    public Set<UUID> getGameUUIDs(){
-        return  games.keySet();
+    public Set<Id> getGameIDs(){
+        return games.keySet();
     }
 
     @TestOnly

--- a/src/main/java/org/iogame/model/battle/Battle.java
+++ b/src/main/java/org/iogame/model/battle/Battle.java
@@ -1,6 +1,6 @@
 package org.iogame.model.battle;
 
-import org.iogame.model.GameObject;
+import org.iogame.core.GameObject;
 import org.iogame.model.planet.Planet;
 
 public class Battle extends GameObject {

--- a/src/main/java/org/iogame/model/fleet/Fleet.java
+++ b/src/main/java/org/iogame/model/fleet/Fleet.java
@@ -1,7 +1,7 @@
 package org.iogame.model.fleet;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.iogame.model.GameObject;
+import org.iogame.core.GameObject;
 import org.iogame.model.battle.Battle;
 import org.iogame.model.planet.Planet;
 import org.iogame.model.player.Player;

--- a/src/main/java/org/iogame/model/fleet/ship/Ship.java
+++ b/src/main/java/org/iogame/model/fleet/ship/Ship.java
@@ -1,6 +1,6 @@
 package org.iogame.model.fleet.ship;
 
-import org.iogame.model.GameObject;
+import org.iogame.core.GameObject;
 
 public class Ship extends GameObject {
 

--- a/src/main/java/org/iogame/model/planet/Planet.java
+++ b/src/main/java/org/iogame/model/planet/Planet.java
@@ -1,6 +1,6 @@
 package org.iogame.model.planet;
 
-import org.iogame.model.GameObject;
+import org.iogame.core.GameObject;
 import org.iogame.model.battle.Battle;
 import org.iogame.model.data.EBuilding;
 import org.iogame.model.fleet.Fleet;

--- a/src/main/java/org/iogame/model/planet/buildings/Building.java
+++ b/src/main/java/org/iogame/model/planet/buildings/Building.java
@@ -1,6 +1,6 @@
 package org.iogame.model.planet.buildings;
 
-import org.iogame.model.GameObject;
+import org.iogame.core.GameObject;
 import org.iogame.model.data.EBuilding;
 import org.iogame.model.data.EResource;
 import org.iogame.model.planet.Planet;

--- a/src/test/java/org/iogame/core/IdTest.java
+++ b/src/test/java/org/iogame/core/IdTest.java
@@ -1,0 +1,47 @@
+package org.iogame.core;
+
+import org.iogame.StaticSettings;
+import org.iogame.model.fleet.Fleet;
+import org.iogame.model.planet.Planet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.iogame.StaticSettings.ENV;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class IdTest {
+
+    @BeforeEach
+    void setup() {
+        ENV = StaticSettings.Environment.DEVELOPMENT;
+    }
+
+    @Test
+    void shouldComputeEqualsBaseOnEnviroment() {
+        Id devId = Id.generate();
+        ENV = StaticSettings.Environment.PRODUCTION;
+        Id prodId = Id.generate();
+
+        assertNotEquals(prodId, devId);
+        assertEquals(devId, devId);
+        assertEquals(prodId, prodId);
+    }
+
+    @Test
+    void testToString() {
+        Id devId = Id.fromString("42");
+        assertEquals(Long.valueOf(42), devId.getValue());
+    }
+
+    @Test
+    void sameIdsForDifferentClasses() {
+        Id planetId1 = Id.generateForClass(Planet.class);
+        Id planetId2 = Id.generateForClass(Planet.class);
+        Id fleetId = Id.generateForClass(Fleet.class);
+
+        assertEquals(0L, planetId1.<Long>getValue());
+        assertEquals(1L, planetId2.<Long>getValue());
+        assertEquals(0L, fleetId.<Long>getValue());
+    }
+}

--- a/src/test/java/org/iogame/core/IdTest.java
+++ b/src/test/java/org/iogame/core/IdTest.java
@@ -29,7 +29,7 @@ class IdTest {
     }
 
     @Test
-    void testToString() {
+    void testFromString() {
         Id devId = Id.fromString("42");
         assertEquals(Long.valueOf(42), devId.getValue());
     }

--- a/src/test/java/org/iogame/main/ServerTest.java
+++ b/src/test/java/org/iogame/main/ServerTest.java
@@ -1,5 +1,6 @@
 package org.iogame.main;
 
+import org.iogame.core.Id;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,8 +32,8 @@ class ServerTest {
 
     @Test
     void shouldGetGamesById() {
-        UUID gameId1 = server.createGame("test1");
-        UUID gameId2 = server.createGame("test2");
+        Id gameId1 = server.createGame("test1");
+        Id gameId2 = server.createGame("test2");
 
         assertEquals("test1", server.getGameById(gameId1).gameName());
         assertEquals("test2", server.getGameById(gameId2).gameName());


### PR DESCRIPTION
I added a static setting which enables us to toggle between `DEVELOPMENT` and `PRODUCTION` state. I'll use it here to generate small consecutive ids for all entities for the default development state.